### PR TITLE
Add persistentvolume resource 

### DIFF
--- a/service/resource/persistentvolume/create.go
+++ b/service/resource/persistentvolume/create.go
@@ -6,12 +6,12 @@ import (
 	"github.com/giantswarm/operatorkit/framework"
 )
 
-// NewCreatePatch is not used
+// NewCreatePatch is not used during persistent volume reconcile
 func (r *Resource) NewCreatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
 	return nil, nil
 }
 
-// ApplyCreateChange is not used
+// ApplyCreateChange is not used during persistent volume reconcile
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, deleteState interface{}) error {
 	return nil
 }

--- a/service/resource/persistentvolume/create.go
+++ b/service/resource/persistentvolume/create.go
@@ -6,12 +6,12 @@ import (
 	"github.com/giantswarm/operatorkit/framework"
 )
 
-// NewCreatePatch is not used during persistent volume reconcile
+// NewCreatePatch is not used during persistent volume reconcile.
 func (r *Resource) NewCreatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
 	return nil, nil
 }
 
-// ApplyCreateChange is not used during persistent volume reconcile
+// ApplyCreateChange is not used during persistent volume reconcile.
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, deleteState interface{}) error {
 	return nil
 }

--- a/service/resource/persistentvolume/create.go
+++ b/service/resource/persistentvolume/create.go
@@ -1,0 +1,17 @@
+package persistentvolume
+
+import (
+	"context"
+
+	"github.com/giantswarm/operatorkit/framework"
+)
+
+// NewCreatePatch is not used
+func (r *Resource) NewCreatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	return nil, nil
+}
+
+// ApplyCreateChange is not used
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, deleteState interface{}) error {
+	return nil
+}

--- a/service/resource/persistentvolume/delete.go
+++ b/service/resource/persistentvolume/delete.go
@@ -8,7 +8,7 @@ import (
 	"github.com/giantswarm/operatorkit/framework"
 )
 
-// NewDeletePatch returns patch to apply on deleted persistent volume
+// NewDeletePatch returns patch to apply on deleted persistent volume.
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
 
 	deleteState, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
@@ -22,7 +22,7 @@ func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desire
 	return patch, nil
 }
 
-// ApplyDeleteChange represents delete patch logic
+// ApplyDeleteChange represents delete patch logic.
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteState interface{}) error {
 	rpv, err := toRecyclePV(deleteState)
 	if err != nil {
@@ -45,7 +45,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteState inter
 }
 
 // newDeleteChange checks wherether persistent volume should be reconciled
-// on delete event
+// on delete event.
 func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
 	deletedVolume, err := toPV(obj)
 	if err != nil {

--- a/service/resource/persistentvolume/delete.go
+++ b/service/resource/persistentvolume/delete.go
@@ -52,15 +52,15 @@ func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desir
 		return nil, microerror.Mask(err)
 	}
 
-	reconcile := isScheduledForCleanup(deletedVolume, cleanupAnnotation)
-
-	r.logger.LogCtx(ctx, "persistentvolume", deletedVolume.Name, cleanupAnnotation, reconcile)
+	r.logger.LogCtx(ctx, "persistentvolume", updatedVolume.Name, "retrieving cleanup annotation", cleanupAnnotation)
+	reconcile := isScheduledForCleanup(updatedVolume, cleanupAnnotation)
+	r.logger.LogCtx(ctx, "persistentvolume", updatedVolume.Name, "reconcile persistent volume", reconcile)
 	if !reconcile {
 		return nil, nil
 	}
 
 	if reflect.DeepEqual(currentState, desiredState) {
-		r.logger.LogCtx(ctx, "persistentvolume", deletedVolume.Name, "recycled", "true")
+		r.logger.LogCtx(ctx, "persistentvolume", updatedVolume.Name, "volume reconciled to desired state", "true")
 		return nil, nil
 	}
 

--- a/service/resource/persistentvolume/delete.go
+++ b/service/resource/persistentvolume/delete.go
@@ -1,0 +1,33 @@
+package persistentvolume
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+)
+
+// NewDeletePatch returns patch to apply on deleted persistent volume
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+// ApplyDeleteChange represents delete patch logic
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteState interface{}) error {
+	return nil
+}
+
+// newDeleteChange checks wherether persistent volume should be reconciled
+// on delete event
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/resource/persistentvolume/error.go
+++ b/service/resource/persistentvolume/error.go
@@ -1,0 +1,24 @@
+package persistentvolume
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}
+
+var missingAnnotationError = microerror.New("missing annotation")
+
+func IsMissingAnnotationError(err error) bool {
+	return microerror.Cause(err) == missingAnnotationError
+}

--- a/service/resource/persistentvolume/error.go
+++ b/service/resource/persistentvolume/error.go
@@ -13,12 +13,14 @@ func IsInvalidConfig(err error) bool {
 
 var wrongTypeError = microerror.New("wrong type")
 
+// IsWrongTypeError asserts wrongTypeError.
 func IsWrongTypeError(err error) bool {
 	return microerror.Cause(err) == wrongTypeError
 }
 
 var missingAnnotationError = microerror.New("missing annotation")
 
+// IsMissingAnnotationError asserts missingAnnotationError.
 func IsMissingAnnotationError(err error) bool {
 	return microerror.Cause(err) == missingAnnotationError
 }

--- a/service/resource/persistentvolume/resource.go
+++ b/service/resource/persistentvolume/resource.go
@@ -69,11 +69,16 @@ func (r *Resource) Underlying() framework.Resource {
 	return r
 }
 
+// isScheduledForCleanup checks whethere persistent volume object has cleanup annotation
 func isScheduledForCleanup(pv *apiv1.PersistentVolume, cleanupAnnotation string) bool {
 	cleanupAnnotationValue, ok := pv.Annotations[cleanupAnnotation]
 	return ok && cleanupAnnotationValue == "true"
 }
 
+// getRecycleStateAnnotation returns current recycle state annotation
+// If it is empty - 'recycled' annotation returned,
+// so that volumes, which were never recycled before by the operator
+// will be considered in the same way as recycled volumes
 func getRecycleStateAnnotation(pv *apiv1.PersistentVolume, recycleStateAnnotation string) (recycleStateAnnotationValue string) {
 	recycleStateAnnotationValue, ok := pv.Annotations[recycleStateAnnotation]
 	if !ok {
@@ -82,6 +87,7 @@ func getRecycleStateAnnotation(pv *apiv1.PersistentVolume, recycleStateAnnotatio
 	return recycleStateAnnotationValue
 }
 
+// toPV converts interface object into PersistentVolume object
 func toPV(v interface{}) (*apiv1.PersistentVolume, error) {
 	if v == nil {
 		return nil, nil
@@ -95,6 +101,7 @@ func toPV(v interface{}) (*apiv1.PersistentVolume, error) {
 	return pv, nil
 }
 
+// toRecyclePV converts interface object into RecyclePersistentVolume object
 func toRecyclePV(v interface{}) (*RecyclePersistentVolume, error) {
 	if v == nil {
 		return nil, nil
@@ -108,6 +115,7 @@ func toRecyclePV(v interface{}) (*RecyclePersistentVolume, error) {
 	return pv, nil
 }
 
+// pvToRecyclePV creates RecyclePersistentVolume object from PersistentVolume object
 func pvToRecyclePV(v interface{}) (*RecyclePersistentVolume, error) {
 	if v == nil {
 		return nil, nil

--- a/service/resource/persistentvolume/resource.go
+++ b/service/resource/persistentvolume/resource.go
@@ -15,14 +15,13 @@ const (
 	recycleStateAnnotation = "pv-cleaner-operator.giantswarm.io/volume-recycle-state"
 )
 
-// RecycleStateAnnotation values
 const (
 	released string = "Released"
 	cleaning string = "Cleaning"
 	recycled string = "Recycled"
 )
 
-// Config describes resource configuration
+// Config describes resource configuration.
 type Config struct {
 	K8sClient kubernetes.Interface
 	Logger    micrologger.Logger
@@ -37,13 +36,13 @@ func DefaultConfig() Config {
 	}
 }
 
-// Resource stores resource configuration
+// Resource stores resource configuration.
 type Resource struct {
 	k8sClient kubernetes.Interface
 	logger    micrologger.Logger
 }
 
-// New is factory for resource objects
+// New is factory for resource objects.
 func New(config Config) (*Resource, error) {
 	if config.K8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
@@ -59,26 +58,26 @@ func New(config Config) (*Resource, error) {
 	return resource, nil
 }
 
-// Name returns name of the managed resource
+// Name returns name of the managed resource.
 func (r *Resource) Name() string {
 	return name
 }
 
-// Underlying returns managed resource object
+// Underlying returns managed resource object.
 func (r *Resource) Underlying() framework.Resource {
 	return r
 }
 
-// isScheduledForCleanup checks whethere persistent volume object has cleanup annotation
+// isScheduledForCleanup checks whethere persistent volume object has cleanup annotation.
 func isScheduledForCleanup(pv *apiv1.PersistentVolume, cleanupAnnotation string) bool {
 	cleanupAnnotationValue, ok := pv.Annotations[cleanupAnnotation]
 	return ok && cleanupAnnotationValue == "true"
 }
 
-// getRecycleStateAnnotation returns current recycle state annotation
+// getRecycleStateAnnotation returns current recycle state annotation.
 // If it is empty - 'recycled' annotation returned,
 // so that volumes, which were never recycled before by the operator
-// will be considered in the same way as recycled volumes
+// will be considered in the same way as recycled volumes.
 func getRecycleStateAnnotation(pv *apiv1.PersistentVolume, recycleStateAnnotation string) (recycleStateAnnotationValue string) {
 	recycleStateAnnotationValue, ok := pv.Annotations[recycleStateAnnotation]
 	if !ok {
@@ -87,7 +86,7 @@ func getRecycleStateAnnotation(pv *apiv1.PersistentVolume, recycleStateAnnotatio
 	return recycleStateAnnotationValue
 }
 
-// toPV converts interface object into PersistentVolume object
+// toPV converts interface object into PersistentVolume object.
 func toPV(v interface{}) (*apiv1.PersistentVolume, error) {
 	if v == nil {
 		return nil, nil
@@ -101,7 +100,7 @@ func toPV(v interface{}) (*apiv1.PersistentVolume, error) {
 	return pv, nil
 }
 
-// toRecyclePV converts interface object into RecyclePersistentVolume object
+// toRecyclePV converts interface object into RecyclePersistentVolume object.
 func toRecyclePV(v interface{}) (*RecyclePersistentVolume, error) {
 	if v == nil {
 		return nil, nil
@@ -115,7 +114,7 @@ func toRecyclePV(v interface{}) (*RecyclePersistentVolume, error) {
 	return pv, nil
 }
 
-// pvToRecyclePV creates RecyclePersistentVolume object from PersistentVolume object
+// pvToRecyclePV creates RecyclePersistentVolume object from PersistentVolume object.
 func pvToRecyclePV(v interface{}) (*RecyclePersistentVolume, error) {
 	if v == nil {
 		return nil, nil

--- a/service/resource/persistentvolume/resource.go
+++ b/service/resource/persistentvolume/resource.go
@@ -1,0 +1,60 @@
+package persistentvolume
+
+import (
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/framework"
+)
+
+const (
+	name = "endpoint"
+)
+
+// Config describes resource configuration
+type Config struct {
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new resource by
+// best effort.
+func DefaultConfig() Config {
+	return Config{
+		K8sClient: nil,
+		Logger:    nil,
+	}
+}
+
+// Resource stores resource configuration
+type Resource struct {
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New is factory for resource objects
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	resource := &Resource{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+	return resource, nil
+}
+
+// Name returns name of the managed resource
+func (r *Resource) Name() string {
+	return name
+}
+
+// Underlying returns managed resource object
+func (r *Resource) Underlying() framework.Resource {
+	return r
+}

--- a/service/resource/persistentvolume/resource.go
+++ b/service/resource/persistentvolume/resource.go
@@ -11,8 +11,8 @@ import (
 
 const (
 	name                   = "persistentvolume"
-	cleanupAnnotation      = "persistentvolume.giantswarm.io/cleanup"
-	recycleStateAnnotation = "persistentvolume.giantswarm.io/recyclestate"
+	cleanupAnnotation      = "volume.kubernetes.io/cleanup-on-release"
+	recycleStateAnnotation = "pv-cleaner-operator.giantswarm.io/volume-recycle-state"
 )
 
 // RecycleStateAnnotation values

--- a/service/resource/persistentvolume/spec.go
+++ b/service/resource/persistentvolume/spec.go
@@ -1,0 +1,11 @@
+package persistentvolume
+
+import apiv1 "k8s.io/api/core/v1"
+
+// RecyclePersistentVolume reflects PersistentVolume
+// with additional RecycleState
+type RecyclePersistentVolume struct {
+	Name         string
+	State        apiv1.PersistentVolumePhase
+	RecycleState string
+}

--- a/service/resource/persistentvolume/spec.go
+++ b/service/resource/persistentvolume/spec.go
@@ -3,7 +3,7 @@ package persistentvolume
 import apiv1 "k8s.io/api/core/v1"
 
 // RecyclePersistentVolume reflects PersistentVolume
-// with additional RecycleState
+// with additional RecycleState.
 type RecyclePersistentVolume struct {
 	Name         string
 	State        apiv1.PersistentVolumePhase

--- a/service/resource/persistentvolume/state.go
+++ b/service/resource/persistentvolume/state.go
@@ -1,0 +1,16 @@
+package persistentvolume
+
+import (
+	"context"
+)
+
+// GetCurrentState returns current state of the recycled persistent volume
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+
+	return nil, nil
+}
+
+// GetDesiredState returns desired state of the recycled persistent volume
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/resource/persistentvolume/state.go
+++ b/service/resource/persistentvolume/state.go
@@ -2,15 +2,33 @@ package persistentvolume
 
 import (
 	"context"
+
+	"github.com/giantswarm/microerror"
 )
 
 // GetCurrentState returns current state of the recycled persistent volume
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
 
-	return nil, nil
+	rpv, err := pvToRecyclePV(obj)
+	if err != nil {
+		return nil, microerror.Maskf(err, "GetCurrentState")
+	}
+
+	return rpv, nil
 }
 
 // GetDesiredState returns desired state of the recycled persistent volume
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
-	return nil, nil
+
+	pv, err := pvToRecyclePV(obj)
+	if err != nil {
+		return nil, microerror.Maskf(err, "GetDesiredState")
+	}
+
+	rpv := &RecyclePersistentVolume{
+		Name:         pv.Name,
+		State:        "Available",
+		RecycleState: recycled,
+	}
+	return rpv, nil
 }

--- a/service/resource/persistentvolume/state.go
+++ b/service/resource/persistentvolume/state.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
-// GetCurrentState returns current state of the recycled persistent volume
+// GetCurrentState returns current state of the recycled persistent volume.
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
 
 	rpv, err := pvToRecyclePV(obj)
@@ -17,7 +17,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	return rpv, nil
 }
 
-// GetDesiredState returns desired state of the recycled persistent volume
+// GetDesiredState returns desired state of the recycled persistent volume.
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
 
 	pv, err := pvToRecyclePV(obj)

--- a/service/resource/persistentvolume/update.go
+++ b/service/resource/persistentvolume/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/giantswarm/operatorkit/framework"
 )
 
-// NewUpdatePatch returns patch to apply on deleted persistent volume
+// NewUpdatePatch returns patch to apply on deleted persistent volume.
 func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
 
 	updateState, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
@@ -22,7 +22,7 @@ func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desire
 	return patch, nil
 }
 
-// ApplyUpdateChange represents delete patch logic
+// ApplyUpdateChange represents delete patch logic.
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateState interface{}) error {
 	rpv, err := toRecyclePV(updateState)
 	if err != nil {
@@ -45,7 +45,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateState inter
 }
 
 // newUpdateChange checks wherether persistent volume should be reconciled
-// on update event
+// on update event.
 func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
 	updatedVolume, err := toPV(obj)
 	if err != nil {

--- a/service/resource/persistentvolume/update.go
+++ b/service/resource/persistentvolume/update.go
@@ -52,14 +52,15 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 		return nil, microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "persistentvolume", updatedVolume.Name, "retrieving cleanup annotation", cleanupAnnotation)
 	reconcile := isScheduledForCleanup(updatedVolume, cleanupAnnotation)
-	r.logger.LogCtx(ctx, "persistentvolume", updatedVolume.Name, cleanupAnnotation, reconcile)
+	r.logger.LogCtx(ctx, "persistentvolume", updatedVolume.Name, "reconcile persistent volume", reconcile)
 	if !reconcile {
 		return nil, nil
 	}
 
 	if reflect.DeepEqual(currentState, desiredState) {
-		r.logger.LogCtx(ctx, "persistentvolume", updatedVolume.Name, "recycled", "true")
+		r.logger.LogCtx(ctx, "persistentvolume", updatedVolume.Name, "volume reconciled to desired state", "true")
 		return nil, nil
 	}
 

--- a/service/resource/persistentvolume/update.go
+++ b/service/resource/persistentvolume/update.go
@@ -1,0 +1,33 @@
+package persistentvolume
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+)
+
+// NewUpdatePatch returns patch to apply on deleted persistent volume
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+// ApplyUpdateChange represents delete patch logic
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateState interface{}) error {
+	return nil
+}
+
+// newUpdateChange checks wherether persistent volume should be reconciled
+// on update event
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}


### PR DESCRIPTION
  This PR adds:
- `RecyclePersistentVolume` resource
- current/desired states checks
- persistent volumes update/delete events processing

If there is a proper annotation on `PersistentVolume` and `RecyclePersistentVolume` current state differs from desired state - update/delete patch is applied. Patch logic will be added in separate PR


